### PR TITLE
feat: recipes as code + DMS lineage emitter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'docker-compose.yaml'
+      - 'ingestion/recipes/**'
+      - '.github/workflows/ec2-deploy.sh'
 
 jobs:
   deploy:

--- a/.github/workflows/dms-lineage.yml
+++ b/.github/workflows/dms-lineage.yml
@@ -3,7 +3,7 @@ name: DMS Lineage Sync
 on:
   schedule:
     # 03:00 UTC = 04:00 Amsterdam (CET) / 05:00 Amsterdam (CEST)
-    # Always runs ≥1 h after Glue ingestion (03:00 Amsterdam) in both winter and summer
+    # Always runs >=1 h after Glue ingestion (03:00 Amsterdam) in both winter and summer
     - cron: '0 3 * * *'
   workflow_dispatch:
 
@@ -24,4 +24,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: eu-west-1
+          DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
         run: python3 ingestion/recipes/dms_lineage.py

--- a/.github/workflows/dms-lineage.yml
+++ b/.github/workflows/dms-lineage.yml
@@ -2,9 +2,9 @@ name: DMS Lineage Sync
 
 on:
   schedule:
-    # 02:00 UTC = 04:00 Amsterdam
-    # Runs after Glue ingestion (03:00 Amsterdam) so Glue tables exist in DataHub
-    - cron: '0 2 * * *'
+    # 03:00 UTC = 04:00 Amsterdam (CET) / 05:00 Amsterdam (CEST)
+    # Always runs ≥1 h after Glue ingestion (03:00 Amsterdam) in both winter and summer
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dms-lineage.yml
+++ b/.github/workflows/dms-lineage.yml
@@ -1,0 +1,27 @@
+name: DMS Lineage Sync
+
+on:
+  schedule:
+    # 02:00 UTC = 04:00 Amsterdam
+    # Runs after Glue ingestion (03:00 Amsterdam) so Glue tables exist in DataHub
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  emit_lineage:
+    name: Emit DMS Lineage to DataHub
+    runs-on: datahub-runner
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pip install "acryl-datahub[dbt]" boto3
+
+      - name: Emit DMS lineage to DataHub
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: eu-west-1
+        run: python3 ingestion/recipes/dms_lineage.py

--- a/.github/workflows/ec2-deploy.sh
+++ b/.github/workflows/ec2-deploy.sh
@@ -91,4 +91,29 @@ until docker compose exec -T mysql mysqladmin ping -h mysql -u datahub --passwor
 done
 echo "MySQL is ready."
 
+
+echo "Waiting for DataHub GMS to be healthy..."
+until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
+  echo "GMS not ready yet, retrying..."
+  sleep 5
+done
+echo "DataHub GMS is healthy."
+
+echo "Deploying ingestion recipes to DataHub UI..."
+deploy_recipe() {
+  local name="$1" schedule="$2" tz="$3" recipe="$4"
+  docker exec datahub-datahub-actions-1 \
+    datahub ingest deploy \
+      --name "$name" \
+      --schedule "$schedule" \
+      --time-zone "$tz" \
+      -c "$recipe" \
+  && echo "✅ Deployed: $name" \
+  || echo "⚠️  Failed to deploy: $name (will retry on next deploy)"
+}
+
+deploy_recipe "DBT"                 "0 0 * * *"  "Europe/Amsterdam" /ingestion/recipes/dbt.yml
+deploy_recipe "Glue"                "0 3 * * *"  "Europe/Amsterdam" /ingestion/recipes/glue.yml
+deploy_recipe "Metabase"            "0 8 * * *"  "Europe/Amsterdam" /ingestion/recipes/metabase.yml
+deploy_recipe "Redshift Production" "0 21 * * *" "Europe/Amsterdam" /ingestion/recipes/redshift_production.yml
 echo "DataHub deployment complete."

--- a/.github/workflows/ec2-deploy.sh
+++ b/.github/workflows/ec2-deploy.sh
@@ -113,9 +113,10 @@ echo "Syncing ingestion credentials into DataHub secrets store..."
 # DataHub recipes use ${SECRET_NAME} substitution resolved from the GMS secrets store
 # (backed by MySQL). Re-upserting on every deploy ensures secrets survive volume resets
 # and stay in sync with AWS Secrets Manager as the source of truth.
+LOGIN_PAYLOAD=$(jq -n --arg password "$CLIENT_SECRET" '{"username":"datahub","password":$password}')
 GMS_TOKEN=$(curl -sf -X POST http://localhost:8080/logIn \
   -H "Content-Type: application/json" \
-  -d "{\"username\":\"datahub\",\"password\":\"${CLIENT_SECRET}\"}" | jq -r '.accessToken')
+  -d "$LOGIN_PAYLOAD" | jq -r '.accessToken')
 
 SECRET_UPSERT_FAILED=0
 

--- a/.github/workflows/ec2-deploy.sh
+++ b/.github/workflows/ec2-deploy.sh
@@ -129,15 +129,19 @@ upsert_datahub_secret() {
     --arg name "$name" \
     --arg value "$value" \
     '{"query":"mutation($name:String!,$value:String!){upsertSecret(input:{name:$name,value:$value}){urn}}","variables":{"name":$name,"value":$value}}')
-  if curl -sf -X POST http://localhost:8080/api/graphql \
+  local response
+  response=$(curl -sf -X POST http://localhost:8080/api/graphql \
     -H "Authorization: Bearer $GMS_TOKEN" \
     -H "Content-Type: application/json" \
-    -d "$payload" \
-    > /dev/null; then
-    echo "✅ Secret upserted: $name"
-  else
-    echo "ERROR: Failed to upsert DataHub secret '$name'" >&2
+    -d "$payload")
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to upsert DataHub secret '$name' (HTTP error)" >&2
     SECRET_UPSERT_FAILED=1
+  elif echo "$response" | jq -e '.errors' > /dev/null 2>&1; then
+    echo "ERROR: GraphQL error upserting secret '$name': $(echo "$response" | jq -r '.errors[0].message')" >&2
+    SECRET_UPSERT_FAILED=1
+  else
+    echo "✅ Secret upserted: $name"
   fi
 }
 

--- a/.github/workflows/ec2-deploy.sh
+++ b/.github/workflows/ec2-deploy.sh
@@ -39,12 +39,22 @@ TOKEN_CREDS=$(aws secretsmanager get-secret-value --region "$AWS_REGION" \
 DATAHUB_TOKEN_SERVICE_SIGNING_KEY=$(echo "$TOKEN_CREDS" | jq -r '.DATAHUB_TOKEN_SERVICE_SIGNING_KEY')
 DATAHUB_TOKEN_SERVICE_SALT=$(echo "$TOKEN_CREDS" | jq -r '.DATAHUB_TOKEN_SERVICE_SALT')
 
+# Ingestion credentials (Metabase + Redshift) — used by recipes as DataHub Secrets.
+# Secret format: {"METABASE_USERNAME":"...","METABASE_PASSWORD":"...","REDSHIFT_USERNAME":"...","REDSHIFT_PASSWORD":"..."}
+INGESTION_CREDS=$(aws secretsmanager get-secret-value --region "$AWS_REGION" \
+  --secret-id "datahub/ingestion-credentials" --query SecretString --output text)
+METABASE_USERNAME=$(echo "$INGESTION_CREDS" | jq -r '.METABASE_USERNAME')
+METABASE_PASSWORD=$(echo "$INGESTION_CREDS" | jq -r '.METABASE_PASSWORD')
+REDSHIFT_USERNAME=$(echo "$INGESTION_CREDS" | jq -r '.REDSHIFT_USERNAME')
+REDSHIFT_PASSWORD=$(echo "$INGESTION_CREDS" | jq -r '.REDSHIFT_PASSWORD')
+
 echo "Secrets retrieved."
 
 # Fail fast if any required value is empty, so we never deploy a half-configured stack.
 for var in CLIENT_SECRET AUTH_OIDC_CLIENT_ID AUTH_OIDC_CLIENT_SECRET \
   MYSQL_PASSWORD MYSQL_ROOT_PASSWORD \
-  DATAHUB_TOKEN_SERVICE_SIGNING_KEY DATAHUB_TOKEN_SERVICE_SALT DATAHUB_VERSION; do
+  DATAHUB_TOKEN_SERVICE_SIGNING_KEY DATAHUB_TOKEN_SERVICE_SALT DATAHUB_VERSION \
+  METABASE_USERNAME METABASE_PASSWORD REDSHIFT_USERNAME REDSHIFT_PASSWORD; do
   if [ -z "${!var:-}" ] || [ "${!var}" = "null" ]; then
     echo "ERROR: required value '$var' is empty; aborting deploy." >&2
     exit 1
@@ -98,6 +108,30 @@ until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
   sleep 5
 done
 echo "DataHub GMS is healthy."
+
+echo "Syncing ingestion credentials into DataHub secrets store..."
+# DataHub recipes use ${SECRET_NAME} substitution resolved from the GMS secrets store
+# (backed by MySQL). Re-upserting on every deploy ensures secrets survive volume resets
+# and stay in sync with AWS Secrets Manager as the source of truth.
+GMS_TOKEN=$(curl -sf -X POST http://localhost:8080/logIn \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"datahub\",\"password\":\"${CLIENT_SECRET}\"}" | jq -r '.accessToken')
+
+upsert_datahub_secret() {
+  local name="$1" value="$2"
+  curl -sf -X POST http://localhost:8080/api/graphql \
+    -H "Authorization: Bearer $GMS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"query\":\"mutation { upsertSecret(input: {name: \\\"${name}\\\", value: \\\"${value}\\\"}) { urn } }\"}" \
+    > /dev/null \
+  && echo "✅ Secret upserted: $name" \
+  || echo "⚠️  Failed to upsert secret: $name"
+}
+
+upsert_datahub_secret "METABASE_USERNAME" "$METABASE_USERNAME"
+upsert_datahub_secret "METABASE_PASSWORD" "$METABASE_PASSWORD"
+upsert_datahub_secret "REDSHIFT_USERNAME" "$REDSHIFT_USERNAME"
+upsert_datahub_secret "REDSHIFT_PASSWORD" "$REDSHIFT_PASSWORD"
 
 echo "Deploying ingestion recipes to DataHub UI..."
 deploy_recipe() {

--- a/.github/workflows/ec2-deploy.sh
+++ b/.github/workflows/ec2-deploy.sh
@@ -156,21 +156,39 @@ if [ "$SECRET_UPSERT_FAILED" -ne 0 ]; then
   exit 1
 fi
 
+echo "Waiting for datahub-actions container to be ready..."
+until docker exec datahub-datahub-actions-1 datahub version > /dev/null 2>&1; do
+  echo "datahub-actions not ready yet, retrying..."
+  sleep 5
+done
+echo "datahub-actions is ready."
+
 echo "Deploying ingestion recipes to DataHub UI..."
+RECIPE_DEPLOY_FAILED=0
+
 deploy_recipe() {
   local name="$1" schedule="$2" tz="$3" recipe="$4"
-  docker exec datahub-datahub-actions-1 \
+  if docker exec datahub-datahub-actions-1 \
     datahub ingest deploy \
       --name "$name" \
       --schedule "$schedule" \
       --time-zone "$tz" \
-      -c "$recipe" \
-  && echo "✅ Deployed: $name" \
-  || echo "⚠️  Failed to deploy: $name (will retry on next deploy)"
+      -c "$recipe"; then
+    echo "✅ Deployed: $name"
+  else
+    echo "ERROR: Failed to deploy recipe '$name'" >&2
+    RECIPE_DEPLOY_FAILED=1
+  fi
 }
 
 deploy_recipe "DBT"                 "0 0 * * *"  "Europe/Amsterdam" /ingestion/recipes/dbt.yml
 deploy_recipe "Glue"                "0 3 * * *"  "Europe/Amsterdam" /ingestion/recipes/glue.yml
 deploy_recipe "Metabase"            "0 8 * * *"  "Europe/Amsterdam" /ingestion/recipes/metabase.yml
 deploy_recipe "Redshift Production" "0 21 * * *" "Europe/Amsterdam" /ingestion/recipes/redshift_production.yml
+
+if [ "$RECIPE_DEPLOY_FAILED" -ne 0 ]; then
+  echo "ERROR: one or more ingestion recipes failed to deploy." >&2
+  exit 1
+fi
+
 echo "DataHub deployment complete."

--- a/.github/workflows/ec2-deploy.sh
+++ b/.github/workflows/ec2-deploy.sh
@@ -117,6 +117,8 @@ GMS_TOKEN=$(curl -sf -X POST http://localhost:8080/logIn \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"datahub\",\"password\":\"${CLIENT_SECRET}\"}" | jq -r '.accessToken')
 
+SECRET_UPSERT_FAILED=0
+
 upsert_datahub_secret() {
   local name="$1" value="$2"
   # Use jq to build the payload so that quotes, backslashes, and newlines in
@@ -126,19 +128,28 @@ upsert_datahub_secret() {
     --arg name "$name" \
     --arg value "$value" \
     '{"query":"mutation($name:String!,$value:String!){upsertSecret(input:{name:$name,value:$value}){urn}}","variables":{"name":$name,"value":$value}}')
-  curl -sf -X POST http://localhost:8080/api/graphql \
+  if curl -sf -X POST http://localhost:8080/api/graphql \
     -H "Authorization: Bearer $GMS_TOKEN" \
     -H "Content-Type: application/json" \
     -d "$payload" \
-    > /dev/null \
-  && echo "✅ Secret upserted: $name" \
-  || echo "⚠️  Failed to upsert secret: $name"
+    > /dev/null; then
+    echo "✅ Secret upserted: $name"
+  else
+    echo "ERROR: Failed to upsert DataHub secret '$name'" >&2
+    SECRET_UPSERT_FAILED=1
+  fi
 }
 
 upsert_datahub_secret "METABASE_USERNAME" "$METABASE_USERNAME"
 upsert_datahub_secret "METABASE_PASSWORD" "$METABASE_PASSWORD"
 upsert_datahub_secret "REDSHIFT_USERNAME" "$REDSHIFT_USERNAME"
 upsert_datahub_secret "REDSHIFT_PASSWORD" "$REDSHIFT_PASSWORD"
+
+if [ "$SECRET_UPSERT_FAILED" -ne 0 ]; then
+  echo "ERROR: one or more DataHub secrets failed to upsert; aborting deploy." >&2
+  echo "Recipes that reference \${METABASE_*} or \${REDSHIFT_*} would run with unresolved credentials." >&2
+  exit 1
+fi
 
 echo "Deploying ingestion recipes to DataHub UI..."
 deploy_recipe() {

--- a/.github/workflows/ec2-deploy.sh
+++ b/.github/workflows/ec2-deploy.sh
@@ -119,10 +119,17 @@ GMS_TOKEN=$(curl -sf -X POST http://localhost:8080/logIn \
 
 upsert_datahub_secret() {
   local name="$1" value="$2"
+  # Use jq to build the payload so that quotes, backslashes, and newlines in
+  # the value are properly JSON-escaped — never interpolate secrets into raw strings.
+  local payload
+  payload=$(jq -n \
+    --arg name "$name" \
+    --arg value "$value" \
+    '{"query":"mutation($name:String!,$value:String!){upsertSecret(input:{name:$name,value:$value}){urn}}","variables":{"name":$name,"value":$value}}')
   curl -sf -X POST http://localhost:8080/api/graphql \
     -H "Authorization: Bearer $GMS_TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{\"query\":\"mutation { upsertSecret(input: {name: \\\"${name}\\\", value: \\\"${value}\\\"}) { urn } }\"}" \
+    -d "$payload" \
     > /dev/null \
   && echo "✅ Secret upserted: $name" \
   || echo "⚠️  Failed to upsert secret: $name"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,6 +65,7 @@ services:
     volumes:
     - ${HOME}/.datahub/plugins:/etc/datahub/plugins
     - ./ingestion/dbt_artifacts:/dbt_artifacts
+    - ./ingestion/recipes:/ingestion/recipes
   datahub-frontend-react:
     depends_on:
       datahub-gms:

--- a/ingestion/recipes/dbt.yml
+++ b/ingestion/recipes/dbt.yml
@@ -1,0 +1,12 @@
+source:
+  type: dbt
+  config:
+    manifest_path: /dbt_artifacts/manifest.json
+    catalog_path: /dbt_artifacts/catalog.json
+    run_results_paths:
+      - /dbt_artifacts/run_results.json
+    target_platform: redshift
+sink:
+  type: datahub-rest
+  config:
+    server: "http://datahub-gms:8080"

--- a/ingestion/recipes/dms_lineage.py
+++ b/ingestion/recipes/dms_lineage.py
@@ -13,6 +13,7 @@ so that Glue tables already exist in DataHub when lineage edges are emitted.
 """
 import json
 import logging
+import os
 
 import boto3
 from datahub.emitter.mce_builder import (
@@ -31,7 +32,8 @@ from datahub.metadata.schema_classes import (
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-DATAHUB_GMS_URL = "http://localhost:8080"
+DATAHUB_GMS_URL = os.environ.get("DATAHUB_GMS_URL", "http://localhost:8080")
+DATAHUB_GMS_TOKEN = os.environ.get("DATAHUB_GMS_TOKEN")
 AWS_REGION = "eu-west-1"
 ENV = "PROD"
 
@@ -66,8 +68,12 @@ def get_endpoint(dms_client: object, arn: str) -> dict:
 def find_glue_tables_for_s3_prefix(
     glue_client: object, bucket: str, folder: str
 ) -> list:
-    """Return (database, table) pairs whose S3 location starts with s3://bucket/folder/."""
-    # Trailing slash prevents folder2 from matching when looking for folder
+    """Return (database, table, inferred_schema, inferred_table) tuples.
+
+    DMS writes to s3://bucket/folder/{schema}/{table}/ so the path components
+    after the prefix let us infer the Aurora source schema and table name even
+    for wildcard replication rules.
+    """
     s3_prefix = f"s3://{bucket}/{folder}".rstrip("/") + "/"
     matches = []
     db_paginator = glue_client.get_paginator("get_databases")
@@ -81,14 +87,22 @@ def find_glue_tables_for_s3_prefix(
                         table.get("StorageDescriptor", {}).get("Location", "")
                     )
                     if location.startswith(s3_prefix):
-                        matches.append((db_name, table["Name"]))
+                        # Extract schema/table from relative path: {schema}/{table}/...
+                        relative = location[len(s3_prefix):].rstrip("/")
+                        parts = relative.split("/")
+                        inferred_schema = parts[0] if len(parts) >= 2 else ""
+                        inferred_table = parts[1] if len(parts) >= 2 else parts[0] if parts else ""
+                        matches.append(
+                            (db_name, table["Name"], inferred_schema, inferred_table)
+                        )
     return matches
 
 
 def parse_explicit_source_tables(table_mappings_json: str) -> list:
     """
     Extract (schema, table) pairs from DMS selection rules.
-    Skips wildcard rules (%) — those are resolved via Glue table discovery.
+    Returns an empty list when all rules use wildcards — callers should
+    fall back to Glue-inferred source tables in that case.
     """
     results = []
     try:
@@ -111,7 +125,7 @@ def parse_explicit_source_tables(table_mappings_json: str) -> list:
 def emit_lineage() -> None:
     dms = boto3.client("dms", region_name=AWS_REGION)
     glue = boto3.client("glue", region_name=AWS_REGION)
-    emitter = DatahubRestEmitter(DATAHUB_GMS_URL)
+    emitter = DatahubRestEmitter(DATAHUB_GMS_URL, token=DATAHUB_GMS_TOKEN)
 
     tasks = get_all_dms_tasks(dms)
     logger.info("Discovered %d DMS tasks", len(tasks))
@@ -151,16 +165,29 @@ def emit_lineage() -> None:
         source_db = source_ep.get("DatabaseName", "")
         explicit_tables = parse_explicit_source_tables(task.get("TableMappings", "{}"))
 
-        # Upstream: Aurora/RDS source tables (explicit names only; wildcards resolved via Glue)
+        # Build upstream Aurora URNs.
+        # Explicit rules: use the declared schema/table names.
+        # Wildcard rules: infer schema/table from the DMS S3 output path structure
+        #   (DMS writes to s3://bucket/folder/{schema}/{table}/).
         input_urns = []
-        for schema, table in explicit_tables:
-            name = f"{source_db}.{schema}.{table}" if source_db else f"{schema}.{table}"
-            input_urns.append(make_dataset_urn(platform, name, ENV))
+        if explicit_tables:
+            for schema, table in explicit_tables:
+                name = f"{source_db}.{schema}.{table}" if source_db else f"{schema}.{table}"
+                input_urns.append(make_dataset_urn(platform, name, ENV))
+        else:
+            for _glue_db, _glue_tbl, inferred_schema, inferred_table in glue_tables:
+                if inferred_schema and inferred_table:
+                    name = (
+                        f"{source_db}.{inferred_schema}.{inferred_table}"
+                        if source_db
+                        else f"{inferred_schema}.{inferred_table}"
+                    )
+                    input_urns.append(make_dataset_urn(platform, name, ENV))
 
         # Downstream: Glue catalog tables (already ingested by the Glue recipe)
         output_urns = [
             make_dataset_urn("glue", f"{db}.{tbl}", ENV)
-            for db, tbl in glue_tables
+            for db, tbl, _s, _t in glue_tables
         ]
 
         flow_urn = make_data_flow_urn("dms", instance_id, ENV)

--- a/ingestion/recipes/dms_lineage.py
+++ b/ingestion/recipes/dms_lineage.py
@@ -196,6 +196,7 @@ def emit_lineage() -> None:
                 for db, tbl, inf_s, inf_t in glue_tables
                 if inf_s and inf_t
             ]
+            seen_sources: set = set()
             for _glue_db, _glue_tbl, inferred_schema, inferred_table in glue_tables:
                 if inferred_schema and inferred_table:
                     name = (
@@ -203,7 +204,9 @@ def emit_lineage() -> None:
                         if source_db
                         else f"{inferred_schema}.{inferred_table}"
                     )
-                    input_urns.append(make_dataset_urn(platform, name, ENV))
+                    if name not in seen_sources:
+                        seen_sources.add(name)
+                        input_urns.append(make_dataset_urn(platform, name, ENV))
 
         # Downstream: only Glue tables whose source was resolved (matched_glue)
         output_urns = [

--- a/ingestion/recipes/dms_lineage.py
+++ b/ingestion/recipes/dms_lineage.py
@@ -66,20 +66,22 @@ def get_endpoint(dms_client: object, arn: str) -> dict:
 def find_glue_tables_for_s3_prefix(
     glue_client: object, bucket: str, folder: str
 ) -> list:
-    """Return (database, table) pairs whose S3 location starts with s3://bucket/folder."""
-    s3_prefix = f"s3://{bucket}/{folder}".rstrip("/")
+    """Return (database, table) pairs whose S3 location starts with s3://bucket/folder/."""
+    # Trailing slash prevents folder2 from matching when looking for folder
+    s3_prefix = f"s3://{bucket}/{folder}".rstrip("/") + "/"
     matches = []
-    resp = glue_client.get_databases()
-    for db in resp["DatabaseList"]:
-        db_name = db["Name"]
-        paginator = glue_client.get_paginator("get_tables")
-        for page in paginator.paginate(DatabaseName=db_name):
-            for table in page["TableList"]:
-                location = (
-                    table.get("StorageDescriptor", {}).get("Location", "")
-                )
-                if location.startswith(s3_prefix):
-                    matches.append((db_name, table["Name"]))
+    db_paginator = glue_client.get_paginator("get_databases")
+    for db_page in db_paginator.paginate():
+        for db in db_page["DatabaseList"]:
+            db_name = db["Name"]
+            table_paginator = glue_client.get_paginator("get_tables")
+            for table_page in table_paginator.paginate(DatabaseName=db_name):
+                for table in table_page["TableList"]:
+                    location = (
+                        table.get("StorageDescriptor", {}).get("Location", "")
+                    )
+                    if location.startswith(s3_prefix):
+                        matches.append((db_name, table["Name"]))
     return matches
 
 

--- a/ingestion/recipes/dms_lineage.py
+++ b/ingestion/recipes/dms_lineage.py
@@ -152,6 +152,14 @@ def emit_lineage() -> None:
             logger.warning("Skipping %s — no S3 bucket in target endpoint", task_id)
             continue
 
+        if not folder:
+            logger.warning(
+                "Skipping %s — BucketFolder is empty; matching against the whole "
+                "bucket would link unrelated Glue tables",
+                task_id,
+            )
+            continue
+
         glue_tables = find_glue_tables_for_s3_prefix(glue, bucket, folder)
         if not glue_tables:
             logger.warning(
@@ -216,6 +224,14 @@ def emit_lineage() -> None:
                 ),
             )
         )
+        if not input_urns:
+            logger.warning(
+                "Skipping lineage emit for %s — could not resolve any upstream "
+                "Aurora URNs (S3 paths did not yield schema/table segments)",
+                task_id,
+            )
+            continue
+
         emitter.emit_mcp(
             MetadataChangeProposalWrapper(
                 entityUrn=job_urn,

--- a/ingestion/recipes/dms_lineage.py
+++ b/ingestion/recipes/dms_lineage.py
@@ -198,6 +198,14 @@ def emit_lineage() -> None:
             for db, tbl, _s, _t in glue_tables
         ]
 
+        if not input_urns:
+            logger.warning(
+                "Skipping lineage emit for %s — could not resolve any upstream "
+                "Aurora URNs (S3 paths did not yield schema/table segments)",
+                task_id,
+            )
+            continue
+
         flow_urn = make_data_flow_urn("dms", instance_id, ENV)
         job_urn = make_data_job_urn("dms", instance_id, task_id, ENV)
 
@@ -224,13 +232,6 @@ def emit_lineage() -> None:
                 ),
             )
         )
-        if not input_urns:
-            logger.warning(
-                "Skipping lineage emit for %s — could not resolve any upstream "
-                "Aurora URNs (S3 paths did not yield schema/table segments)",
-                task_id,
-            )
-            continue
 
         emitter.emit_mcp(
             MetadataChangeProposalWrapper(

--- a/ingestion/recipes/dms_lineage.py
+++ b/ingestion/recipes/dms_lineage.py
@@ -179,10 +179,23 @@ def emit_lineage() -> None:
         #   (DMS writes to s3://bucket/folder/{schema}/{table}/).
         input_urns = []
         if explicit_tables:
+            explicit_set = {(s.lower(), t.lower()) for s, t in explicit_tables}
+            # Only include Glue tables whose inferred path matches a declared rule,
+            # so wildcard-replicated tables do not get mismatched lineage.
+            matched_glue = [
+                (db, tbl)
+                for db, tbl, inf_s, inf_t in glue_tables
+                if (inf_s.lower(), inf_t.lower()) in explicit_set
+            ]
             for schema, table in explicit_tables:
                 name = f"{source_db}.{schema}.{table}" if source_db else f"{schema}.{table}"
                 input_urns.append(make_dataset_urn(platform, name, ENV))
         else:
+            matched_glue = [
+                (db, tbl)
+                for db, tbl, inf_s, inf_t in glue_tables
+                if inf_s and inf_t
+            ]
             for _glue_db, _glue_tbl, inferred_schema, inferred_table in glue_tables:
                 if inferred_schema and inferred_table:
                     name = (
@@ -192,10 +205,10 @@ def emit_lineage() -> None:
                     )
                     input_urns.append(make_dataset_urn(platform, name, ENV))
 
-        # Downstream: Glue catalog tables (already ingested by the Glue recipe)
+        # Downstream: only Glue tables whose source was resolved (matched_glue)
         output_urns = [
             make_dataset_urn("glue", f"{db}.{tbl}", ENV)
-            for db, tbl, _s, _t in glue_tables
+            for db, tbl in matched_glue
         ]
 
         if not input_urns:

--- a/ingestion/recipes/dms_lineage.py
+++ b/ingestion/recipes/dms_lineage.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+DMS Lineage Emitter for DataHub.
+
+Dynamically discovers AWS DMS replication tasks and emits lineage:
+  Aurora/RDS source tables -> DMS DataJob -> Glue catalog tables
+
+Fully automatic: new DMS tasks and new tables are picked up on each run
+without any manual changes to this script.
+
+Schedule: runs daily after the Glue ingestion (which catalogs the S3 output)
+so that Glue tables already exist in DataHub when lineage edges are emitted.
+"""
+import json
+import logging
+
+import boto3
+from datahub.emitter.mce_builder import (
+    make_data_flow_urn,
+    make_data_job_urn,
+    make_dataset_urn,
+)
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.rest_emitter import DatahubRestEmitter
+from datahub.metadata.schema_classes import (
+    DataFlowInfoClass,
+    DataJobInfoClass,
+    DataJobInputOutputClass,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DATAHUB_GMS_URL = "http://localhost:8080"
+AWS_REGION = "eu-west-1"
+ENV = "PROD"
+
+ENGINE_TO_PLATFORM = {
+    "aurora": "mysql",
+    "mysql": "mysql",
+    "postgres": "postgres",
+    "aurora-postgresql": "postgres",
+}
+
+
+def get_all_dms_tasks(dms_client: object) -> list:
+    tasks = []
+    kwargs: dict = {"WithoutSettings": False}
+    while True:
+        resp = dms_client.describe_replication_tasks(**kwargs)
+        tasks.extend(resp["ReplicationTasks"])
+        marker = resp.get("Marker")
+        if not marker:
+            break
+        kwargs["Marker"] = marker
+    return tasks
+
+
+def get_endpoint(dms_client: object, arn: str) -> dict:
+    resp = dms_client.describe_endpoints(
+        Filters=[{"Name": "endpoint-arn", "Values": [arn]}]
+    )
+    return resp["Endpoints"][0] if resp["Endpoints"] else {}
+
+
+def find_glue_tables_for_s3_prefix(
+    glue_client: object, bucket: str, folder: str
+) -> list:
+    """Return (database, table) pairs whose S3 location starts with s3://bucket/folder."""
+    s3_prefix = f"s3://{bucket}/{folder}".rstrip("/")
+    matches = []
+    resp = glue_client.get_databases()
+    for db in resp["DatabaseList"]:
+        db_name = db["Name"]
+        paginator = glue_client.get_paginator("get_tables")
+        for page in paginator.paginate(DatabaseName=db_name):
+            for table in page["TableList"]:
+                location = (
+                    table.get("StorageDescriptor", {}).get("Location", "")
+                )
+                if location.startswith(s3_prefix):
+                    matches.append((db_name, table["Name"]))
+    return matches
+
+
+def parse_explicit_source_tables(table_mappings_json: str) -> list:
+    """
+    Extract (schema, table) pairs from DMS selection rules.
+    Skips wildcard rules (%) — those are resolved via Glue table discovery.
+    """
+    results = []
+    try:
+        rules = json.loads(table_mappings_json).get("rules", [])
+        for rule in rules:
+            if (
+                rule.get("rule-type") == "selection"
+                and rule.get("rule-action") == "include"
+            ):
+                locator = rule.get("object-locator", {})
+                schema = locator.get("schema-name", "%")
+                table = locator.get("table-name", "%")
+                if "%" not in schema and "%" not in table:
+                    results.append((schema, table))
+    except Exception as exc:
+        logger.warning("Could not parse table mappings: %s", exc)
+    return results
+
+
+def emit_lineage() -> None:
+    dms = boto3.client("dms", region_name=AWS_REGION)
+    glue = boto3.client("glue", region_name=AWS_REGION)
+    emitter = DatahubRestEmitter(DATAHUB_GMS_URL)
+
+    tasks = get_all_dms_tasks(dms)
+    logger.info("Discovered %d DMS tasks", len(tasks))
+
+    for task in tasks:
+        task_id = task["ReplicationTaskIdentifier"]
+        instance_id = task["ReplicationInstanceArn"].split(":")[-1]
+
+        source_ep = get_endpoint(dms, task["SourceEndpointArn"])
+        target_ep = get_endpoint(dms, task["TargetEndpointArn"])
+
+        if target_ep.get("EngineName", "").lower() != "s3":
+            logger.info(
+                "Skipping %s — target is not S3 (%s)",
+                task_id,
+                target_ep.get("EngineName"),
+            )
+            continue
+
+        s3 = target_ep.get("S3Settings", {})
+        bucket = s3.get("BucketName", "")
+        folder = s3.get("BucketFolder", "")
+        if not bucket:
+            logger.warning("Skipping %s — no S3 bucket in target endpoint", task_id)
+            continue
+
+        glue_tables = find_glue_tables_for_s3_prefix(glue, bucket, folder)
+        if not glue_tables:
+            logger.warning(
+                "No Glue tables found for %s at s3://%s/%s", task_id, bucket, folder
+            )
+            continue
+
+        platform = ENGINE_TO_PLATFORM.get(
+            source_ep.get("EngineName", "").lower(), "mysql"
+        )
+        source_db = source_ep.get("DatabaseName", "")
+        explicit_tables = parse_explicit_source_tables(task.get("TableMappings", "{}"))
+
+        # Upstream: Aurora/RDS source tables (explicit names only; wildcards resolved via Glue)
+        input_urns = []
+        for schema, table in explicit_tables:
+            name = f"{source_db}.{schema}.{table}" if source_db else f"{schema}.{table}"
+            input_urns.append(make_dataset_urn(platform, name, ENV))
+
+        # Downstream: Glue catalog tables (already ingested by the Glue recipe)
+        output_urns = [
+            make_dataset_urn("glue", f"{db}.{tbl}", ENV)
+            for db, tbl in glue_tables
+        ]
+
+        flow_urn = make_data_flow_urn("dms", instance_id, ENV)
+        job_urn = make_data_job_urn("dms", instance_id, task_id, ENV)
+
+        emitter.emit_mcp(
+            MetadataChangeProposalWrapper(
+                entityUrn=flow_urn,
+                aspect=DataFlowInfoClass(
+                    name=instance_id,
+                    customProperties={"platform": "AWS DMS"},
+                ),
+            )
+        )
+        emitter.emit_mcp(
+            MetadataChangeProposalWrapper(
+                entityUrn=job_urn,
+                aspect=DataJobInfoClass(
+                    name=task_id,
+                    type="BATCH",
+                    customProperties={
+                        "migrationType": task.get("MigrationType", ""),
+                        "status": task.get("Status", ""),
+                        "replicationInstance": instance_id,
+                    },
+                ),
+            )
+        )
+        emitter.emit_mcp(
+            MetadataChangeProposalWrapper(
+                entityUrn=job_urn,
+                aspect=DataJobInputOutputClass(
+                    inputDatasets=input_urns,
+                    outputDatasets=output_urns,
+                ),
+            )
+        )
+
+        logger.info(
+            "%s: %d upstream Aurora tables -> %d downstream Glue tables",
+            task_id,
+            len(input_urns),
+            len(output_urns),
+        )
+
+    logger.info("DMS lineage emission complete")
+
+
+if __name__ == "__main__":
+    emit_lineage()

--- a/ingestion/recipes/glue.yml
+++ b/ingestion/recipes/glue.yml
@@ -1,0 +1,8 @@
+source:
+  type: glue
+  config:
+    aws_region: eu-west-1
+sink:
+  type: datahub-rest
+  config:
+    server: "http://datahub-gms:8080"

--- a/ingestion/recipes/metabase.yml
+++ b/ingestion/recipes/metabase.yml
@@ -1,0 +1,25 @@
+source:
+  type: metabase
+  config:
+    connect_uri: "https://metabase.studocu.com/"
+    username: "${METABASE_USERNAME}"
+    password: "${METABASE_PASSWORD}"
+    database_alias_map:
+      "Data Warehouse - Sensitive (Ops - Management)": production_sensitive
+      "Data Warehouse": production
+      "Data Warehouse - Sensitive (ALL)": production_sensitive
+      "Data Lake": raw_data
+      "Raw data": raw_data
+      "Data Warehouse - Sensitive (Ops)": production_sensitive
+      "Dev": dev
+    engine_platform_map:
+      redshift: redshift
+      glue: glue
+      athena: athena
+    stateful_ingestion:
+      enabled: true
+      remove_stale_metadata: true
+sink:
+  type: datahub-rest
+  config:
+    server: "http://datahub-gms:8080"

--- a/ingestion/recipes/redshift_production.yml
+++ b/ingestion/recipes/redshift_production.yml
@@ -1,0 +1,21 @@
+source:
+  type: redshift
+  config:
+    host_port: "production-studocu-datawarehouse.c3rc335oay5d.eu-west-1.redshift.amazonaws.com:5439"
+    database: production
+    username: "${REDSHIFT_USERNAME}"
+    password: "${REDSHIFT_PASSWORD}"
+    table_lineage_mode: stl_scan_based
+    include_table_lineage: true
+    include_tables: true
+    include_views: true
+    profiling:
+      enabled: true
+      profile_table_level_only: false
+      sample_size: 1000
+    stateful_ingestion:
+      enabled: true
+sink:
+  type: datahub-rest
+  config:
+    server: "http://datahub-gms:8080"


### PR DESCRIPTION
## Summary

- Extracts all DataHub ingestion source configs from the UI and stores them as YAML recipe files in the repo under `ingestion/recipes/`
- Updates `docker-compose.yaml` to mount `ingestion/recipes/` into the `datahub-actions` container
- Updates `ec2-deploy.sh` to auto-deploy all recipes into the DataHub UI on every deploy (using `datahub ingest deploy`) — no more manual clicking after a restart
- Adds a dynamic DMS lineage emitter (`dms_lineage.py`) that auto-discovers AWS DMS tasks, resolves their Glue table outputs, and emits lineage edges to DataHub
- Adds a GitHub Actions workflow (`dms-lineage.yml`) that runs the DMS lineage emitter daily at 02:00 UTC (after Glue ingestion at 03:00 Amsterdam)

## Recipe files added

| File | Schedule |
|---|---|
| `ingestion/recipes/dbt.yml` | 00:00 Amsterdam |
| `ingestion/recipes/glue.yml` | 03:00 Amsterdam |
| `ingestion/recipes/metabase.yml` | 08:00 Amsterdam |
| `ingestion/recipes/redshift_production.yml` | 21:00 Amsterdam |
| `ingestion/recipes/dms_lineage.py` | via GitHub Actions |

## How DMS lineage works

On each run the script:
1. Lists all DMS replication tasks via AWS API
2. Resolves the S3 target prefix for each task
3. Finds all Glue tables whose S3 location matches that prefix (already in DataHub via Glue ingestion)
4. Emits `DataFlow` + `DataJob` + lineage edges: Aurora source → DMS task → Glue tables

New DMS tasks and new source tables are picked up automatically — no code changes needed.

## Reviewers
@AminuIsrael @fabio-luiz-nogueira

Made with [Cursor](https://cursor.com)